### PR TITLE
Feature 47/assign team leader

### DIFF
--- a/src/main/java/com/teamrocket/tms/controllers/ProjectController.java
+++ b/src/main/java/com/teamrocket/tms/controllers/ProjectController.java
@@ -2,7 +2,7 @@ package com.teamrocket.tms.controllers;
 
 import com.teamrocket.tms.models.dtos.ProjectDTO;
 import com.teamrocket.tms.services.project.ProjectService;
-import jakarta.validation.Valid;
+//import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,11 +18,11 @@ public class ProjectController {
         this.projectService = projectService;
     }
 
-    @PostMapping
-    public ResponseEntity<ProjectDTO> createProject(@RequestBody @Valid ProjectDTO projectDTO) {
-        ProjectDTO createdProject = projectService.createProject(projectDTO);
-        return ResponseEntity.ok(createdProject);
-    }
+//    @PostMapping
+//    public ResponseEntity<ProjectDTO> createProject(@RequestBody @Valid ProjectDTO projectDTO) {
+//        ProjectDTO createdProject = projectService.createProject(projectDTO);
+//        return ResponseEntity.ok(createdProject);
+//    }
 
     @GetMapping("/{id}")
     public ResponseEntity<ProjectDTO> getProjectById(@PathVariable Long id) {

--- a/src/main/java/com/teamrocket/tms/controllers/TaskController.java
+++ b/src/main/java/com/teamrocket/tms/controllers/TaskController.java
@@ -2,7 +2,7 @@ package com.teamrocket.tms.controllers;
 
 import com.teamrocket.tms.models.dtos.TaskDTO;
 import com.teamrocket.tms.services.task.TaskService;
-import jakarta.validation.Valid;
+//import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,10 +18,10 @@ public class TaskController {
         this.taskService = taskService;
     }
 
-    @PostMapping
-    public ResponseEntity<TaskDTO> createTask(@Valid @RequestBody TaskDTO taskDTO) {
-        return ResponseEntity.ok(null);
-    }
+//    @PostMapping
+//    public ResponseEntity<TaskDTO> createTask(@Valid @RequestBody TaskDTO taskDTO) {
+//        return ResponseEntity.ok(null);
+//    }
 
     @GetMapping
     public ResponseEntity<List<TaskDTO>> getTasks() {

--- a/src/main/java/com/teamrocket/tms/controllers/TeamController.java
+++ b/src/main/java/com/teamrocket/tms/controllers/TeamController.java
@@ -2,6 +2,7 @@ package com.teamrocket.tms.controllers;
 
 import com.teamrocket.tms.models.dtos.TeamDTO;
 import com.teamrocket.tms.services.team.TeamService;
+//import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/teamrocket/tms/controllers/TeamController.java
+++ b/src/main/java/com/teamrocket/tms/controllers/TeamController.java
@@ -18,11 +18,10 @@ public class TeamController {
         this.teamService = teamService;
     }
 
-    @PostMapping
-    public ResponseEntity<TeamDTO> createTeam(@Valid @RequestBody TeamDTO teamDTO){
+//    @PostMapping
+//    public ResponseEntity<TeamDTO> createTeam(@Valid @RequestBody TeamDTO teamDTO){
 //        return ResponseEntity.ok(teamService.createTeam(teamDTO));
-        return null;
-    }
+//    }
 
     @GetMapping
     public ResponseEntity<List<TeamDTO>> getAllTeams(){

--- a/src/main/java/com/teamrocket/tms/controllers/TeamController.java
+++ b/src/main/java/com/teamrocket/tms/controllers/TeamController.java
@@ -2,7 +2,6 @@ package com.teamrocket.tms.controllers;
 
 import com.teamrocket.tms.models.dtos.TeamDTO;
 import com.teamrocket.tms.services.team.TeamService;
-import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/com/teamrocket/tms/controllers/UserController.java
+++ b/src/main/java/com/teamrocket/tms/controllers/UserController.java
@@ -66,9 +66,9 @@ public class UserController {
         return ResponseEntity.ok(userService.createTeam(userId, teamDTO));
     }
 
-    @PostMapping("/{userId}/teams/{teamId}/{leaderId}")
-    public ResponseEntity<TeamDTO> assignTeamLeader(@PathVariable Long userId, @PathVariable Long teamId, @PathVariable Long leaderId) {
-        return ResponseEntity.ok(userService.assignTeamLeader(userId, teamId, leaderId));
+    @PostMapping("/{userId}/teams/{teamId}/{targetUserId}")
+    public ResponseEntity<TeamDTO> assignTeamLeader(@PathVariable Long userId, @PathVariable Long teamId, @PathVariable Long targetUserId) {
+        return ResponseEntity.ok(userService.assignTeamLeader(userId, teamId, targetUserId));
     }
 
     @PutMapping("/{userId}/teams/{teamId}/{targetProjectId}")

--- a/src/main/java/com/teamrocket/tms/controllers/UserController.java
+++ b/src/main/java/com/teamrocket/tms/controllers/UserController.java
@@ -61,4 +61,9 @@ public class UserController {
     public ResponseEntity<TeamDTO> createTeam(@PathVariable Long userId, @Valid @RequestBody TeamDTO teamDTO) {
         return ResponseEntity.ok(userService.createTeam(userId, teamDTO));
     }
+
+    @PostMapping("/{userId}/teams/{teamId}/{leaderId}")
+    public ResponseEntity<TeamDTO> assignTeamLeader(@PathVariable Long userId, @PathVariable Long teamId, @PathVariable Long leaderId) {
+        return ResponseEntity.ok(userService.assignTeamLeader(userId, teamId, leaderId));
+    }
 }

--- a/src/main/java/com/teamrocket/tms/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/teamrocket/tms/exceptions/GlobalExceptionHandler.java
@@ -4,7 +4,9 @@ import com.teamrocket.tms.exceptions.project.ProjectAlreadyExistsException;
 import com.teamrocket.tms.exceptions.project.ProjectNotFoundException;
 import com.teamrocket.tms.exceptions.task.TaskAlreadyExistsException;
 import com.teamrocket.tms.exceptions.task.TaskNotFoundException;
+import com.teamrocket.tms.exceptions.user.UsersAreEqualsException;
 import com.teamrocket.tms.exceptions.team.TeamAlreadyExistsException;
+import com.teamrocket.tms.exceptions.team.TeamAlreadyHasTeamLeaderException;
 import com.teamrocket.tms.exceptions.team.TeamNotFoundException;
 import com.teamrocket.tms.exceptions.user.UserAlreadyExistsException;
 import com.teamrocket.tms.exceptions.user.UserNotFoundException;
@@ -58,6 +60,16 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(TeamAlreadyExistsException.class)
     public ResponseEntity<Object> handleTeamAlreadyExistsException(TeamAlreadyExistsException e) {
+        return getResponse(e, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(TeamAlreadyHasTeamLeaderException.class)
+    public ResponseEntity<Object> handleTeamAlreadyHasTeamLeader(TeamAlreadyHasTeamLeaderException e) {
+        return getResponse(e, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(UsersAreEqualsException.class)
+    public ResponseEntity<Object> handlePMCannotBeTM(UsersAreEqualsException e) {
         return getResponse(e, HttpStatus.CONFLICT);
     }
 

--- a/src/main/java/com/teamrocket/tms/exceptions/team/TeamAlreadyExistsException.java
+++ b/src/main/java/com/teamrocket/tms/exceptions/team/TeamAlreadyExistsException.java
@@ -2,7 +2,5 @@ package com.teamrocket.tms.exceptions.team;
 
 public class TeamAlreadyExistsException extends RuntimeException{
 
-    public TeamAlreadyExistsException(String message){
-        super(message);
-    }
+    public TeamAlreadyExistsException(String message){ super(message); }
 }

--- a/src/main/java/com/teamrocket/tms/exceptions/team/TeamAlreadyHasTeamLeaderException.java
+++ b/src/main/java/com/teamrocket/tms/exceptions/team/TeamAlreadyHasTeamLeaderException.java
@@ -1,0 +1,8 @@
+package com.teamrocket.tms.exceptions.team;
+
+public class TeamAlreadyHasTeamLeaderException extends RuntimeException{
+
+    public TeamAlreadyHasTeamLeaderException(String message){
+        super(message);
+    }
+}

--- a/src/main/java/com/teamrocket/tms/exceptions/user/UsersAreEqualsException.java
+++ b/src/main/java/com/teamrocket/tms/exceptions/user/UsersAreEqualsException.java
@@ -1,0 +1,6 @@
+package com.teamrocket.tms.exceptions.user;
+
+public class UsersAreEqualsException extends RuntimeException{
+
+    public UsersAreEqualsException(String message){ super(message); }
+}

--- a/src/main/java/com/teamrocket/tms/models/dtos/TeamDTO.java
+++ b/src/main/java/com/teamrocket/tms/models/dtos/TeamDTO.java
@@ -17,8 +17,7 @@ public class TeamDTO {
     @Size(min = 3, max = 30, message = "must be between 3 and 30 characters")
     private String name;
 
-    @Size(max = 30, message = "max characters is 30")
-    private String teamLeader;
+    private Long teamLeaderId;
 
     private Project project;
 

--- a/src/main/java/com/teamrocket/tms/models/entities/Team.java
+++ b/src/main/java/com/teamrocket/tms/models/entities/Team.java
@@ -1,5 +1,6 @@
 package com.teamrocket.tms.models.entities;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.Data;
 
@@ -19,12 +20,13 @@ public class Team {
     private String name;
 
     @Column(name = "team_leader")
-    private Long teamLeader;
+    private Long teamLeaderId;
 
     @OneToOne
     @JoinColumn(name = "project_id")
     private Project project;
 
     @OneToMany(mappedBy = "team")
+    @JsonManagedReference
     private List<User> userList = new ArrayList<>();
 }

--- a/src/main/java/com/teamrocket/tms/models/entities/Team.java
+++ b/src/main/java/com/teamrocket/tms/models/entities/Team.java
@@ -18,8 +18,8 @@ public class Team {
     @Column(name = "name", length = 30, nullable = false, unique = true)
     private String name;
 
-    @Column(name = "team_leader", length = 30)
-    private String teamLeader;
+    @Column(name = "team_leader")
+    private Long teamLeader;
 
     @OneToOne
     @JoinColumn(name = "project_id")

--- a/src/main/java/com/teamrocket/tms/models/entities/User.java
+++ b/src/main/java/com/teamrocket/tms/models/entities/User.java
@@ -1,5 +1,6 @@
 package com.teamrocket.tms.models.entities;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.teamrocket.tms.utils.enums.Role;
 import jakarta.persistence.*;
 import lombok.Data;
@@ -33,5 +34,6 @@ public class User {
 
     @ManyToOne(fetch = FetchType.EAGER)
     @JoinColumn(name = "team_id")
+    @JsonBackReference
     private Team team;
 }

--- a/src/main/java/com/teamrocket/tms/services/team/TeamService.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamService.java
@@ -1,11 +1,7 @@
 package com.teamrocket.tms.services.team;
 
 import com.teamrocket.tms.models.dtos.TeamDTO;
-<<<<<<< HEAD
-import com.teamrocket.tms.models.entities.User;
-=======
 import com.teamrocket.tms.models.entities.Team;
->>>>>>> dev
 
 import java.util.List;
 
@@ -17,11 +13,9 @@ public interface TeamService {
 
     TeamDTO getTeamById(Long id);
 
-<<<<<<< HEAD
     TeamDTO assignTeamLeader(Long teamId, Long leaderId);
-=======
+
     Team updateTeam(Team team);
 
     void validateTeamIsAssignable(TeamDTO teamDTO);
->>>>>>> dev
 }

--- a/src/main/java/com/teamrocket/tms/services/team/TeamService.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamService.java
@@ -1,6 +1,7 @@
 package com.teamrocket.tms.services.team;
 
 import com.teamrocket.tms.models.dtos.TeamDTO;
+import com.teamrocket.tms.models.entities.User;
 
 import java.util.List;
 
@@ -11,4 +12,6 @@ public interface TeamService {
     List<TeamDTO> getAllTeams();
 
     TeamDTO getTeamById(Long id);
+
+    TeamDTO assignTeamLeader(Long teamId, Long leaderId);
 }

--- a/src/main/java/com/teamrocket/tms/services/team/TeamService.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamService.java
@@ -15,6 +15,8 @@ public interface TeamService {
 
     TeamDTO assignTeamLeader(Long teamId, Long leaderId);
 
+    void validateTeamAlreadyHasTeamLeader(Long teamId);
+
     Team updateTeam(Team team);
 
     void validateTeamIsAssignable(TeamDTO teamDTO);

--- a/src/main/java/com/teamrocket/tms/services/team/TeamServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamServiceImpl.java
@@ -2,6 +2,7 @@ package com.teamrocket.tms.services.team;
 
 import com.teamrocket.tms.exceptions.team.TeamNotFoundException;
 import com.teamrocket.tms.models.dtos.TeamDTO;
+import com.teamrocket.tms.models.entities.Task;
 import com.teamrocket.tms.models.entities.Team;
 import com.teamrocket.tms.repositories.TeamRepository;
 import lombok.extern.slf4j.Slf4j;
@@ -58,13 +59,19 @@ public class TeamServiceImpl implements TeamService {
                 .orElseThrow(() -> new TeamNotFoundException("Team with id: " + teamId + " not found"));
         log.info("Team with id: {} retrieved", teamId);
 
-        teamServiceValidation.validateTeamAlreadyHasTeamLeader(team);
-
         team.setTeamLeaderId(leaderId);
         Team savedTeam = teamRepository.save(team);
         log.info("Team {} : {} set teamLeader to {}", savedTeam.getId(), savedTeam.getName(), leaderId);
 
         return modelMapper.map(savedTeam, TeamDTO.class);
+    }
+
+    @Override
+    public void validateTeamAlreadyHasTeamLeader(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamNotFoundException("Team with id: " + teamId + " not found"));
+
+        teamServiceValidation.validateTeamAlreadyHasTeamLeader(team);
     }
 
     @Override

--- a/src/main/java/com/teamrocket/tms/services/team/TeamServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamServiceImpl.java
@@ -3,6 +3,7 @@ package com.teamrocket.tms.services.team;
 import com.teamrocket.tms.exceptions.team.TeamNotFoundException;
 import com.teamrocket.tms.models.dtos.TeamDTO;
 import com.teamrocket.tms.models.entities.Team;
+import com.teamrocket.tms.models.entities.User;
 import com.teamrocket.tms.repositories.TeamRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -50,5 +51,18 @@ public class TeamServiceImpl implements TeamService {
         log.info("Team with id: {} retrieved", id);
 
         return modelMapper.map(team, TeamDTO.class);
+    }
+
+    @Override
+    public TeamDTO assignTeamLeader(Long teamId, Long leaderId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(() -> new TeamNotFoundException("Team with id: " + teamId + " not found"));
+        log.info("Team with id: {} retrieved", teamId);
+
+        team.setTeamLeader(leaderId);
+        Team savedTeam = teamRepository.save(team);
+        log.info("Team {} : {} set teamLeader to {}", savedTeam.getId(), savedTeam.getName(), leaderId);
+
+        return modelMapper.map(savedTeam, TeamDTO.class);
     }
 }

--- a/src/main/java/com/teamrocket/tms/services/team/TeamServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamServiceImpl.java
@@ -3,7 +3,6 @@ package com.teamrocket.tms.services.team;
 import com.teamrocket.tms.exceptions.team.TeamNotFoundException;
 import com.teamrocket.tms.models.dtos.TeamDTO;
 import com.teamrocket.tms.models.entities.Team;
-import com.teamrocket.tms.models.entities.User;
 import com.teamrocket.tms.repositories.TeamRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
@@ -59,7 +58,9 @@ public class TeamServiceImpl implements TeamService {
                 .orElseThrow(() -> new TeamNotFoundException("Team with id: " + teamId + " not found"));
         log.info("Team with id: {} retrieved", teamId);
 
-        team.setTeamLeader(leaderId);
+        teamServiceValidation.validateTeamAlreadyHasTeamLeader(team);
+
+        team.setTeamLeaderId(leaderId);
         Team savedTeam = teamRepository.save(team);
         log.info("Team {} : {} set teamLeader to {}", savedTeam.getId(), savedTeam.getName(), leaderId);
 

--- a/src/main/java/com/teamrocket/tms/services/team/TeamServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamServiceImpl.java
@@ -53,7 +53,6 @@ public class TeamServiceImpl implements TeamService {
     }
 
     @Override
-<<<<<<< HEAD
     public TeamDTO assignTeamLeader(Long teamId, Long leaderId) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new TeamNotFoundException("Team with id: " + teamId + " not found"));
@@ -66,7 +65,9 @@ public class TeamServiceImpl implements TeamService {
         log.info("Team {} : {} set teamLeader to {}", savedTeam.getId(), savedTeam.getName(), leaderId);
 
         return modelMapper.map(savedTeam, TeamDTO.class);
-=======
+    }
+
+    @Override
     public Team updateTeam(Team team) {
         return teamRepository.save(team);
     }
@@ -74,6 +75,5 @@ public class TeamServiceImpl implements TeamService {
     @Override
     public void validateTeamIsAssignable(TeamDTO teamDTO) {
         teamServiceValidation.validateTeamIsAssignable(teamDTO);
->>>>>>> dev
     }
 }

--- a/src/main/java/com/teamrocket/tms/services/team/TeamServiceValidation.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamServiceValidation.java
@@ -1,8 +1,11 @@
 package com.teamrocket.tms.services.team;
 
 import com.teamrocket.tms.models.dtos.TeamDTO;
+import com.teamrocket.tms.models.entities.Team;
 
 public interface TeamServiceValidation {
 
     void validateTeamAlreadyExists(TeamDTO teamDTO);
+
+    void validateTeamAlreadyHasTeamLeader(Team team);
 }

--- a/src/main/java/com/teamrocket/tms/services/team/TeamServiceValidationImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/team/TeamServiceValidationImpl.java
@@ -1,6 +1,7 @@
 package com.teamrocket.tms.services.team;
 
 import com.teamrocket.tms.exceptions.team.TeamAlreadyExistsException;
+import com.teamrocket.tms.exceptions.team.TeamAlreadyHasTeamLeaderException;
 import com.teamrocket.tms.models.dtos.TeamDTO;
 import com.teamrocket.tms.models.entities.Team;
 import com.teamrocket.tms.repositories.TeamRepository;
@@ -21,6 +22,13 @@ public class TeamServiceValidationImpl implements TeamServiceValidation {
 
         if (foundTeam != null) {
             throw new TeamAlreadyExistsException("A team with name: " + teamDTO.getName() + " already exists");
+        }
+    }
+
+    @Override
+    public void validateTeamAlreadyHasTeamLeader(Team team) {
+        if (team.getTeamLeaderId() != null) {
+            throw new TeamAlreadyHasTeamLeaderException("Team with name: " + team.getName() + " already has a team leader.");
         }
     }
 }

--- a/src/main/java/com/teamrocket/tms/services/user/UserService.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserService.java
@@ -16,6 +16,8 @@ public interface UserService {
 
     UserDTO getUserById(Long id);
 
+    UserDTO updateUser(Long userId, UserDTO userDTO);
+
     TaskDTO createTask(TaskDTO taskDTO, long id);
 
     TaskDTO getTaskById(Long userId, Long taskId);
@@ -24,5 +26,5 @@ public interface UserService {
 
     TeamDTO createTeam(Long userId, TeamDTO teamDTO);
 
-    UserDTO updateUser(Long userId, UserDTO userDTO);
+    TeamDTO assignTeamLeader(Long userId, Long teamId, Long leaderId);
 }

--- a/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
@@ -3,6 +3,7 @@ package com.teamrocket.tms.services.user;
 import com.teamrocket.tms.exceptions.user.UserNotFoundException;
 import com.teamrocket.tms.models.dtos.TaskDTO;
 import com.teamrocket.tms.models.dtos.TeamDTO;
+import com.teamrocket.tms.models.entities.Team;
 import com.teamrocket.tms.services.task.TaskService;
 import com.teamrocket.tms.models.dtos.ProjectDTO;
 import com.teamrocket.tms.models.dtos.UserDTO;
@@ -26,10 +27,8 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final TaskService taskService;
     private final ModelMapper modelMapper;
-
     private final UserServiceValidation userServiceValidation;
     private final ProjectService projectService;
-
     private final TeamService teamService;
 
     public UserServiceImpl(UserRepository userRepository, ModelMapper modelMapper, UserServiceValidation userServiceValidation, ProjectService projectService, TaskService taskService, TeamService teamService) {
@@ -134,9 +133,12 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new UserNotFoundException("User with the id " + leaderId + " not found."));
         log.info("User {} : {} retrieved. From assignTeamLeader.", userId, user.getLastName());
 
+        userServiceValidation.validateAreUsersEquals(user, leader);
+
         leader.setRole(Role.TEAMLEADER);
+        leader.setTeam(modelMapper.map(teamService.getTeamById(teamId), Team.class));
         User savedUser = userRepository.save(leader);
-        log.info("User {} : {} set role to PM. From assignTeamLeader.", savedUser.getId(), savedUser.getLastName());
+        log.info("User {} : {} added to the team {} set role to PM. From assignTeamLeader.", savedUser.getId(), savedUser.getLastName(), leader.getTeam());
 
         return teamService.assignTeamLeader(teamId, leaderId);
     }

--- a/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
@@ -159,10 +159,10 @@ public class UserServiceImpl implements UserService {
         User targetUser = userRepository.findById(targetUserId)
                 .orElseThrow(() -> new UserNotFoundException("User with the id " + targetUserId + " not found."));
         log.info("User {} : {} retrieved. From assignTeamLeader.", userId, user.getLastName());
-        userServiceValidation.validateUserRoleCanPerformAction(targetUser, Role.SENIOR);
 
         userServiceValidation.validateAreUsersEquals(user, targetUser);
         teamService.validateTeamAlreadyHasTeamLeader(teamId);
+        userServiceValidation.validateUserRoleCanPerformAction(targetUser, Role.SENIOR);
 
         targetUser.setRole(Role.TEAM_LEADER);
         targetUser.setTeam(modelMapper.map(teamService.getTeamById(teamId), Team.class));

--- a/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
@@ -150,24 +150,25 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public TeamDTO assignTeamLeader(Long userId, Long teamId, Long leaderId) {
+    public TeamDTO assignTeamLeader(Long userId, Long teamId, Long targetUserId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("User with the id " + userId + " not found."));
         log.info("User {} : {} retrieved. From assignTeamLeader.", userId, user.getLastName());
         userServiceValidation.validateUserRoleCanPerformAction(user, Role.PROJECT_MANAGER);
 
-        User leader = userRepository.findById(leaderId)
-                .orElseThrow(() -> new UserNotFoundException("User with the id " + leaderId + " not found."));
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new UserNotFoundException("User with the id " + targetUserId + " not found."));
         log.info("User {} : {} retrieved. From assignTeamLeader.", userId, user.getLastName());
 
-        userServiceValidation.validateAreUsersEquals(user, leader);
+        userServiceValidation.validateAreUsersEquals(user, targetUser);
+        teamService.validateTeamAlreadyHasTeamLeader(teamId);
 
-        leader.setRole(Role.TEAM_LEADER);
-        leader.setTeam(modelMapper.map(teamService.getTeamById(teamId), Team.class));
-        User savedUser = userRepository.save(leader);
-        log.info("User {} : {} added to the team {} set role to PM. From assignTeamLeader.", savedUser.getId(), savedUser.getLastName(), leader.getTeam());
+        targetUser.setRole(Role.TEAM_LEADER);
+        targetUser.setTeam(modelMapper.map(teamService.getTeamById(teamId), Team.class));
+        User savedUser = userRepository.save(targetUser);
+        log.info("User {} : {} added to the team {} set role to PM. From assignTeamLeader.", savedUser.getId(), savedUser.getLastName(), targetUser.getTeam());
 
-        return teamService.assignTeamLeader(teamId, leaderId);
+        return teamService.assignTeamLeader(teamId, targetUserId);
     }
 
     @Override

--- a/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
@@ -159,6 +159,7 @@ public class UserServiceImpl implements UserService {
         User targetUser = userRepository.findById(targetUserId)
                 .orElseThrow(() -> new UserNotFoundException("User with the id " + targetUserId + " not found."));
         log.info("User {} : {} retrieved. From assignTeamLeader.", userId, user.getLastName());
+        userServiceValidation.validateUserRoleCanPerformAction(targetUser, Role.SENIOR);
 
         userServiceValidation.validateAreUsersEquals(user, targetUser);
         teamService.validateTeamAlreadyHasTeamLeader(teamId);

--- a/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserServiceImpl.java
@@ -122,4 +122,22 @@ public class UserServiceImpl implements UserService {
 
         return teamService.createTeam(teamDTO);
     }
+
+    @Override
+    public TeamDTO assignTeamLeader(Long userId, Long teamId, Long leaderId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("User with the id " + userId + " not found."));
+        log.info("User {} : {} retrieved. From assignTeamLeader.", userId, user.getLastName());
+        userServiceValidation.validateUserRoleCanPerformAction(user, Role.PROJECTMANAGER);
+
+        User leader = userRepository.findById(leaderId)
+                .orElseThrow(() -> new UserNotFoundException("User with the id " + leaderId + " not found."));
+        log.info("User {} : {} retrieved. From assignTeamLeader.", userId, user.getLastName());
+
+        leader.setRole(Role.TEAMLEADER);
+        User savedUser = userRepository.save(leader);
+        log.info("User {} : {} set role to PM. From assignTeamLeader.", savedUser.getId(), savedUser.getLastName());
+
+        return teamService.assignTeamLeader(teamId, leaderId);
+    }
 }

--- a/src/main/java/com/teamrocket/tms/services/user/UserServiceValidation.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserServiceValidation.java
@@ -8,4 +8,5 @@ public interface UserServiceValidation {
 
     void validateUserAlreadyExists(UserDTO userDTO);
     void validateUserRoleCanPerformAction(User user, Role...validRoles);
+    void validateAreUsersEquals(User user, User secondUser);
 }

--- a/src/main/java/com/teamrocket/tms/services/user/UserServiceValidationImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserServiceValidationImpl.java
@@ -1,5 +1,6 @@
 package com.teamrocket.tms.services.user;
 
+import com.teamrocket.tms.exceptions.user.UsersAreEqualsException;
 import com.teamrocket.tms.exceptions.user.UserAlreadyExistsException;
 import com.teamrocket.tms.exceptions.user.UserUnauthorizedActionException;
 import com.teamrocket.tms.models.dtos.UserDTO;
@@ -33,6 +34,13 @@ public class UserServiceValidationImpl implements UserServiceValidation {
         if(Arrays.stream(validRoles).noneMatch(role -> role == user.getRole())){
             log.info("User {} : {} with role {} tried action not permitted for this role.", user.getId(), user.getLastName(), user.getRole().getRoleLabel());
             throw new UserUnauthorizedActionException("Based on your role, you cannot perform this action");
+        }
+    }
+
+    @Override
+    public void validateAreUsersEquals(User user, User secondUser) {
+        if (user.equals(secondUser)) {
+            throw new UsersAreEqualsException("Users are the same.");
         }
     }
 }

--- a/src/main/java/com/teamrocket/tms/services/user/UserServiceValidationImpl.java
+++ b/src/main/java/com/teamrocket/tms/services/user/UserServiceValidationImpl.java
@@ -33,7 +33,7 @@ public class UserServiceValidationImpl implements UserServiceValidation {
     public void validateUserRoleCanPerformAction(User user, Role...validRoles){
         if(Arrays.stream(validRoles).noneMatch(role -> role == user.getRole())){
             log.info("User {} : {} with role {} tried action not permitted for this role.", user.getId(), user.getLastName(), user.getRole().getRoleLabel());
-            throw new UserUnauthorizedActionException("Based on your role, you cannot perform this action");
+            throw new UserUnauthorizedActionException("Based on user role, action cannot be completed.");
         }
     }
 


### PR DESCRIPTION
Changed teamLeader to Long(userId) so even if a user changes his details, the teamLead field will still point to the correct user. Added API to assign teamLeader. Added validation for team already having a teamLeader and validation for PM not setting him up as TL.

